### PR TITLE
prevent from duplicated calling delegate methods

### DIFF
--- a/Sources/CreditCardScanner/CameraView.swift
+++ b/Sources/CreditCardScanner/CameraView.swift
@@ -199,6 +199,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
             delegate?.didError(with: CreditCardScannerError(kind: .capture))
+            delegate = nil
             return
         }
 
@@ -212,6 +213,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate {
         guard let fullCameraImage = cgImage,
             let croppedImage = fullCameraImage.cropping(to: regionOfInterest) else {
             delegate?.didError(with: CreditCardScannerError(kind: .capture))
+            delegate = nil
             return
         }
 

--- a/Sources/CreditCardScanner/ImageAnalyzer.swift
+++ b/Sources/CreditCardScanner/ImageAnalyzer.swift
@@ -46,6 +46,7 @@ final class ImageAnalyzer {
         } catch {
             let e = CreditCardScannerError(kind: .photoProcessing, underlyingError: error)
             delegate?.didFinishAnalyzation(with: .failure(e))
+            delegate = nil
         }
     }
 
@@ -124,6 +125,7 @@ final class ImageAnalyzer {
 
         if strongSelf.selectedCard.number != nil {
             strongSelf.delegate?.didFinishAnalyzation(with: .success(strongSelf.selectedCard))
+            strongSelf.delegate = nil
         }
     }
 }


### PR DESCRIPTION
AnalyzerやカメラViewから連続で実行されるメソッドをそのまま利用者側に通知することにより、
利用者側でpopViewControllerを複数回実行しないように制御しなければならないような挙動になっていたため、
一度しかDelegateメソッドが呼ばれないように修正します。