### PR TITLE
Support NavigationViews

### DIFF
--- a/Sources/CreditCardScanner/CreditCardScannerViewController.swift
+++ b/Sources/CreditCardScanner/CreditCardScannerViewController.swift
@@ -71,8 +71,9 @@ open class CreditCardScannerViewController: UIViewController {
         fatalError("Not implemented")
     }
 
-    override open func viewDidLoad() {
-        super.viewDidLoad()
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.analyzer = ImageAnalyzer(delegate: self)
         layoutSubviews()
         setupLabelsAndButtons()
         AVCaptureDevice.authorize { [weak self] authoriazed in

--- a/Sources/CreditCardScanner/CreditCardScannerViewController.swift
+++ b/Sources/CreditCardScanner/CreditCardScannerViewController.swift
@@ -73,7 +73,7 @@ open class CreditCardScannerViewController: UIViewController {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.analyzer = ImageAnalyzer(delegate: self)
+        
         layoutSubviews()
         setupLabelsAndButtons()
         AVCaptureDevice.authorize { [weak self] authoriazed in


### PR DESCRIPTION
What about change **`viewDidLoad`** to **`viewWillAppear`**, re-initializing ImageAnalyzer for NavigationView?
When users came back from the subview(result) to the root view(scanner view) in NavigationView, I think that `viewDidLoad` is not gonna be called.